### PR TITLE
go: Rename module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
-module github.com/sasha-s/go-deadlock
-
+module github.com/cilium/go-deadlock
 
 require github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect


### PR DESCRIPTION
Rename module to github.com/cilium/go-deadlock